### PR TITLE
[2022/12/20] feat/nameFix >> 말 이름 변경 가능하게 구현, ResultView UI 수정

### DIFF
--- a/HorseRace/HorseRace.xcodeproj/project.pbxproj
+++ b/HorseRace/HorseRace.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3296D0BA2892BDE4001C1847 /* HorseRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3296D0B92892BDE4001C1847 /* HorseRaceTests.swift */; };
 		3296D0C42892BDE4001C1847 /* HorseRaceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3296D0C32892BDE4001C1847 /* HorseRaceUITests.swift */; };
 		3296D0C62892BDE4001C1847 /* HorseRaceUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3296D0C52892BDE4001C1847 /* HorseRaceUITestsLaunchTests.swift */; };
+		32AD9CC42951C2690042D445 /* Extension+KeyBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AD9CC32951C2690042D445 /* Extension+KeyBoard.swift */; };
 		32E19A3828D31E70007EF964 /* startButtonSound.wav in Resources */ = {isa = PBXBuildFile; fileRef = 32E19A3528D31E70007EF964 /* startButtonSound.wav */; };
 		32E19A3928D31E70007EF964 /* negativeSound.wav in Resources */ = {isa = PBXBuildFile; fileRef = 32E19A3628D31E70007EF964 /* negativeSound.wav */; };
 		32E19A3A28D31E70007EF964 /* changeSound.wav in Resources */ = {isa = PBXBuildFile; fileRef = 32E19A3728D31E70007EF964 /* changeSound.wav */; };
@@ -71,6 +72,7 @@
 		3296D0BF2892BDE4001C1847 /* HorseRaceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HorseRaceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3296D0C32892BDE4001C1847 /* HorseRaceUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorseRaceUITests.swift; sourceTree = "<group>"; };
 		3296D0C52892BDE4001C1847 /* HorseRaceUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorseRaceUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		32AD9CC32951C2690042D445 /* Extension+KeyBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+KeyBoard.swift"; sourceTree = "<group>"; };
 		32E19A3528D31E70007EF964 /* startButtonSound.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = startButtonSound.wav; sourceTree = "<group>"; };
 		32E19A3628D31E70007EF964 /* negativeSound.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = negativeSound.wav; sourceTree = "<group>"; };
 		32E19A3728D31E70007EF964 /* changeSound.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = changeSound.wav; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				3296D0AE2892BDE4001C1847 /* Preview Content */,
 				A3E0FD4128D5AC3800E48092 /* Launch Screen.storyboard */,
 				A3E0FD4328D5AD3300E48092 /* AppDelegate.swift */,
+				32AD9CC32951C2690042D445 /* Extension+KeyBoard.swift */,
 			);
 			path = HorseRace;
 			sourceTree = "<group>";
@@ -354,6 +357,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC2F8D6428D34557003C8F3F /* EndParticles.swift in Sources */,
+				32AD9CC42951C2690042D445 /* Extension+KeyBoard.swift in Sources */,
 				3284738A28B4C15100BF498D /* FinalGameProcessingView.swift in Sources */,
 				A39FCEAD28C5ECE30078E19F /* GameStartView.swift in Sources */,
 				CC585C6528D2C56C000DC4A7 /* SoundSetting.swift in Sources */,

--- a/HorseRace/HorseRace/ContentView.swift
+++ b/HorseRace/HorseRace/ContentView.swift
@@ -4,19 +4,20 @@ struct ContentView: View {
     @State var mode: Mode = .GameStart
     @State var horseCount: Int = 2
     @State var resultInfo: [Int] = []
+    @State var horseNames = ["1번마", "2번마", "3번마", "4번마", "5번마", "6번마", "7번마", "8번마"]
     let BGM = SoundSetting(forResouce: "MA_JingleRepublic_TrendyJumpingYouth_Main", withExtension: "wav")
     
     var body: some View {
         ZStack {
             switch mode {
             case .GameStart:
-                GameStartView(mode: $mode, horseCount: $horseCount)
+                GameStartView(mode: $mode, horseCount: $horseCount, horseNames: $horseNames)
             case .FirstGame:
                 GameProcessingView(mode: $mode, horseCount: $horseCount)
             case .LastGame:
                 FinalGameProcessingView(mode: $mode, horseCount: $horseCount, resultInfo: $resultInfo)
             case .Rank:
-                ResultView(mode: $mode, resultInfo: $resultInfo)
+                ResultView(mode: $mode, resultInfo: $resultInfo, horseNames: $horseNames)
             }
         }
         .onAppear{

--- a/HorseRace/HorseRace/Extension+KeyBoard.swift
+++ b/HorseRace/HorseRace/Extension+KeyBoard.swift
@@ -1,0 +1,14 @@
+//
+//  Extension+KeyBoard.swift
+//  HorseRace
+//
+//  Created by 이창형 on 2022/12/20.
+//
+
+import SwiftUI
+
+extension View {
+    func endTextEditing() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/HorseRace/HorseRace/GameStartView.swift
+++ b/HorseRace/HorseRace/GameStartView.swift
@@ -133,5 +133,8 @@ struct GameStartView: View {
                 }
             }
         }
+        .onTapGesture {
+            self.endTextEditing()
+        }
     }
 }

--- a/HorseRace/HorseRace/GameStartView.swift
+++ b/HorseRace/HorseRace/GameStartView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct GameStartView: View {
     @Binding var mode: Mode
     @Binding var horseCount: Int
+    @Binding var horseNames: [String]
     
 
     let startButtonSound = SoundSetting(forResouce: "startButtonSound", withExtension: "wav")
@@ -94,9 +95,14 @@ struct GameStartView: View {
                 
                 HStack(spacing: 0) {
                     ForEach(1...horseCount, id:\.self) { num in
-                        Image("horse\(num)").resizable()
-                            .frame(maxHeight: 200, alignment: .center)
-                            .scaledToFit()
+                        VStack {
+                            Image("horse\(num)").resizable()
+                                .frame(maxHeight: 200, alignment: .center)
+                                .scaledToFit()
+                    
+                                TextField("\(num)번마", text: $horseNames[num - 1])
+                                .multilineTextAlignment(.center)
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/HorseRace/HorseRace/ResultView.swift
+++ b/HorseRace/HorseRace/ResultView.swift
@@ -315,6 +315,8 @@ struct ResultView: View {
                         ForEach(4..<7, id: \.self) { i in
                             content(i, rankingInfo[i].horseNum, rankingInfo[i].second)
                         }
+                        content(0, rankingInfo[0].horseNum, rankingInfo[0].second)
+                            .opacity(0)
                     }
                 }
             } else if num == 8 {

--- a/HorseRace/HorseRace/ResultView.swift
+++ b/HorseRace/HorseRace/ResultView.swift
@@ -13,13 +13,16 @@ struct ResultView: View {
     
     @Binding var mode: Mode
     @Binding var resultInfo: [Int]
+    @Binding var horseNames: [String]
+    
     typealias RankingInfo = (horseNum: Int, second: Float)
     @State private var capsuleWidth: CGFloat = .zero
     @State private var circleWidth: CGFloat = .zero
     
-    init(mode: Binding<Mode>, resultInfo: Binding<[Int]>) {
+    init(mode: Binding<Mode>, resultInfo: Binding<[Int]>, horseNames: Binding<[String]>) {
         self._mode = mode
         self._resultInfo = resultInfo
+        self._horseNames = horseNames
         if resultInfo.count == 2 || resultInfo.count == 4 {
             self.rows = Array<GridItem>(repeating: GridItem(.flexible(), spacing: 8, alignment: .leading),
                                         count: 2)
@@ -118,13 +121,13 @@ struct ResultView: View {
                                     .foregroundColor(.black)
                                     .font(.footnote.bold())
                                     .frame(width: circleWidth)
-
+                                
                                 HStack {
                                     Text("경주마")
                                         .foregroundColor(.black)
                                         .font(.footnote.bold())
                                         .frame(maxWidth: .infinity)
-
+                                    
                                     Text("걸린시간")
                                         .foregroundColor(.black)
                                         .font(.footnote.bold())
@@ -150,34 +153,40 @@ struct ResultView: View {
                                 .onPreferenceChange(SizePreferenceKey.self) { size in
                                     circleWidth = size.width
                                 }
-
+                            
                             HStack(spacing: 0) {
                                 Image("horse\(num+1)\(rankingInfo.count < 4 ? "byOne" : "byTwo")")
                                     .resizable()
                                     .scaledToFit()
                                     .clipShape(Capsule())
-
+                                
                                 HStack(spacing: 12) {
                                     VStack(alignment: .leading, spacing: 0) {
-                                        Text("\(num+1)번마")
-                                            .bold()
-                                            .foregroundColor(Color(hex: "481B15"))
-
-                                        Text("Number \(numString(num+1))")
-                                            .font(.caption)
-                                            .foregroundColor(Color(hex: "9E7B76"))
-                                            .frame(maxWidth: 80)
-                                            .lineLimit(1)
-                                            .minimumScaleFactor(0.8)
+                                        if horseNames[num] == ""{
+                                            Text("\(num + 1)번마")
+                                                .bold()
+                                                .foregroundColor(Color(hex: "481B15"))
+                                        } else {
+                                            Text("\(horseNames[num])")
+                                                .bold()
+                                                .foregroundColor(Color(hex: "481B15"))
+                                        }
+                                        
+                                        //                                        Text("Number \(numString(num+1))")
+                                        //                                            .font(.caption)
+                                        //                                            .foregroundColor(Color(hex: "9E7B76"))
+                                        //                                            .frame(maxWidth: 80)
+                                        //                                            .lineLimit(1)
+                                        //                                            .minimumScaleFactor(0.8)
                                     }
-
+                                    
                                     Text(getTimeLiteral(second))
                                         .font(.subheadline)
                                         .bold()
                                         .lineLimit(1)
                                         .minimumScaleFactor(0.6)
                                         .foregroundColor(Color(hex: "481B15"))
-
+                                    
                                 }
                             }
                             .padding(.trailing, 30)
@@ -216,7 +225,7 @@ struct ResultView: View {
             .padding(.horizontal, 60)
             .padding(.vertical, 38)
             
-
+            
         }
         .ignoresSafeArea()
     }
@@ -227,7 +236,7 @@ struct ResultView: View {
         let millisecond = value - Float(second)
         return String(second) + "s " + String(format: "%.2f", millisecond).dropFirst(2) + "ms"
     }
-
+    
     struct RankingGridView<ItemView: View>: View {
         
         var num: Int
@@ -326,16 +335,16 @@ struct ResultView: View {
     }
 }
 
-struct ResultView_Previews: PreviewProvider {
-
-    private static var info = [108, 42, 50]
-
-    static var previews: some View {
-        ResultView(mode: .constant(.Rank), resultInfo: .constant(info))
-            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
-            .previewInterfaceOrientation(.landscapeLeft)
-    }
-}
+//struct ResultView_Previews: PreviewProvider {
+//
+//    private static var info = [108, 42, 50]
+//
+//    static var previews: some View {
+//        ResultView(mode: .constant(.Rank), resultInfo: .constant(info), horseNames: <#Binding<[String]>#>)
+//            .previewDevice(PreviewDevice(rawValue: "iPhone 13"))
+//            .previewInterfaceOrientation(.landscapeLeft)
+//    }
+//}
 
 struct SizePreferenceKey: PreferenceKey {
     static var defaultValue: CGSize = .zero


### PR DESCRIPTION
|Xcode|
|:---:|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/71262367/208644730-f4aef58d-d768-4622-943b-23823404a706.mp4">|

# 작업내용
- 말 이름을 변경 가능하게 구현
- 이름 설정 안해도 게임 가능
- 터치시 키보드 내림
- 게임 껐다키면 초기화
- 7명 게임 결과화면 UI 수정