### PR TITLE
[Fix] ResultView 레이아웃 수정

### DIFF
--- a/HorseRace/HorseRace/ResultView.swift
+++ b/HorseRace/HorseRace/ResultView.swift
@@ -160,37 +160,29 @@ struct ResultView: View {
                                     .scaledToFit()
                                     .clipShape(Capsule())
                                 
-                                HStack(spacing: 12) {
-                                    VStack(alignment: .leading, spacing: 0) {
-                                        if horseNames[num] == ""{
-                                            Text("\(num + 1)번마")
-                                                .bold()
-                                                .foregroundColor(Color(hex: "481B15"))
-                                        } else {
-                                            Text("\(horseNames[num])")
-                                                .bold()
-                                                .foregroundColor(Color(hex: "481B15"))
-                                        }
-                                        
-                                        //                                        Text("Number \(numString(num+1))")
-                                        //                                            .font(.caption)
-                                        //                                            .foregroundColor(Color(hex: "9E7B76"))
-                                        //                                            .frame(maxWidth: 80)
-                                        //                                            .lineLimit(1)
-                                        //                                            .minimumScaleFactor(0.8)
-                                    }
-                                    
-                                    Text(getTimeLiteral(second))
-                                        .font(.subheadline)
+                                Spacer()
+                                
+                                HStack(spacing: 0) {
+                                    Text(horseNames[num] == "" ? "\(num + 1)번마" : "\(horseNames[num])")
                                         .bold()
                                         .lineLimit(1)
                                         .minimumScaleFactor(0.6)
                                         .foregroundColor(Color(hex: "481B15"))
                                     
+                                    Spacer()
+                                    
+                                    Text(getTimeLiteral(second))
+                                        .font(.subheadline)
+                                        .bold()
+                                        .multilineTextAlignment(.leading)
+                                        .lineLimit(1)
+                                        .foregroundColor(Color(hex: "481B15"))
+                                        .padding(.trailing, 30)
+                                        .frame(width: 100)
+                                    
                                 }
                             }
-                            .padding(.trailing, 30)
-                            .frame(maxHeight: 65)
+                            .frame(minWidth: 180, maxWidth: 280, maxHeight: 65)
                             .background(
                                 Capsule()
                                     .fill(Color.white)


### PR DESCRIPTION
### 수정 사항
* 글자 길이에 따라 달라졌던 ResultView의 레이아웃을 수정했습니다!
* **말 사진** <--Spacer--> **말 이름** <--Spacer--> **시간** 으로 구성되었습니다.
* 말 이름이 길 경우 크기를 최대 0.6배로 줄여서 많은 글자가 보일 수 있도록 하였습니다.

![KakaoTalk_Photo_2022-12-20-21-08-19 001](https://user-images.githubusercontent.com/45297745/208663765-17d621fb-16cd-4e54-a43c-fde913f9e06b.png)
![KakaoTalk_Photo_2022-12-20-21-08-19 002](https://user-images.githubusercontent.com/45297745/208663783-e9dc9086-2e70-4167-978e-70017f0aa2f6.png)
![KakaoTalk_Photo_2022-12-20-21-08-19 003](https://user-images.githubusercontent.com/45297745/208663790-40c431c4-2f60-42cc-a024-f461c1c7e258.png)
